### PR TITLE
Separate FileDialogController to DialogController and ProjectService

### DIFF
--- a/ropa/backend/backend.py
+++ b/ropa/backend/backend.py
@@ -1,5 +1,4 @@
 from ropper import RopperService
-import json
 
 
 class Backend:
@@ -135,32 +134,6 @@ class Backend:
                 gadgets[i]['info'] = 'pop-pop-ret'
 
         return gadgets
-
-    #######################################
-    # PROJECT TOOLS
-    #######################################
-
-    def open_project(self, file):
-        save_data = None
-        with open(file, 'r') as infile:
-            save_data = json.load(infile)
-
-        self.set_filename(save_data['filename'])
-        self.set_arch(save_data['arch'])
-        self.activate()
-        self.chain = save_data['chain']
-        self.user_blocks = save_data['user_blocks']
-
-    def save_project(self, file):
-        with open(file, 'w') as outfile:
-            save_data = {
-                'chain': self.chain,
-                'user_blocks': self.user_blocks,
-                'filename': self.filename,
-                'arch': self.arch
-            }
-            json.dump(save_data, outfile)
-            outfile.close()
 
 
 def test():

--- a/ropa/gui/controller/__init__.py
+++ b/ropa/gui/controller/__init__.py
@@ -1,4 +1,4 @@
-from file_dialog_controller import FileDialogController  # noqa
+from dialog_controller import DialogController  # noqa
 from badbytes_input_controller import BadbytesInputController  # noqa
 from filter_input_controller import FilterInputController  # noqa
 from list_key_controller import ListKeyController 	# noqa

--- a/ropa/gui/controller/dialog_controller.py
+++ b/ropa/gui/controller/dialog_controller.py
@@ -4,23 +4,8 @@ from ropa.backend import architectures
 from ropa.gui import UI_PATH
 
 
-class FileDialogController:
-    def new_file_dialog(self, filename=None):
-        dialog = qg.QFileDialog()
-        dialog.setWindowTitle('Choose binary')
-        dialog.setFileMode(qg.QFileDialog.AnyFile)
-
-        if filename is None:
-            if dialog.exec_():
-                filename = str(dialog.selectedFiles()[0])
-            else:
-                raise Exception('Failed to open dialog')
-
-        arch = self.open_arch_dialog()
-        print(repr(filename), arch)
-        return filename, arch
-
-    def open_file_dialog(self):
+class DialogController:
+    def file_dialog(self):
         dialog = qg.QFileDialog()
         dialog.setWindowTitle('Open File')
         dialog.setFileMode(qg.QFileDialog.AnyFile)
@@ -30,7 +15,7 @@ class FileDialogController:
             return filenames[0]
         raise Exception('Failed to open dialog')
 
-    def open_arch_dialog(self):
+    def arch_dialog(self):
         dialog = uic.loadUi(UI_PATH + '/arch_dialog.ui')
         dialog.setWindowTitle('Select Architecture')
         arch_table = dialog.findChild(qg.QTableWidget, 'arch_table')

--- a/ropa/gui/controller/menu_item_controller.py
+++ b/ropa/gui/controller/menu_item_controller.py
@@ -1,34 +1,27 @@
 import os
 
-from file_dialog_controller import FileDialogController
+from ropa.services import ProjectService
 
 
 class MenuItemController:
     def __init__(self, app):
         self.app = app
-        self.file_dialog_controller = FileDialogController()
+        self.project_service = ProjectService(app)
 
     def _get_backend(self):
         return self.app.backend
 
     def start_new_project(self, filepath=None):
-        filepath, arch = self.file_dialog_controller.new_file_dialog(filepath)
+        filepath, arch = self.project_service.new_file(filepath)
         self.app.setWindowTitle(self.app.app_name + ' - ' +
                                 os.path.basename(str(filepath)))
-        self._get_backend().set_arch(arch)
-        self._get_backend().set_filename(str(filepath))
-        self._get_backend().activate()
         self.app._on_open_project()
 
     def open_project(self, filepath=None):
-        if filepath is None:
-            filepath = self.file_dialog_controller.open_file_dialog()
-        print("Opened " + str(filepath))
-        self._get_backend().open_project(str(filepath))
-        filename = str(self._get_backend().get_filename())
-        self.app.setWindowTitle(self.app.app_name + ' - ' + filename)
+        self.project_service.open_file(filepath)
+        self.app.setWindowTitle(self.app.app_name + ' - ' +
+                                self._get_backend().get_filename())
         self.app._on_open_project()
 
     def save_project(self):
-        filepath = self.file_dialog_controller.open_file_dialog()
-        self._get_backend().save_project(str(filepath))
+        self.project_service.save_file()

--- a/ropa/services/__init__.py
+++ b/ropa/services/__init__.py
@@ -1,1 +1,2 @@
 from export_service import ExportService  # noqa
+from project_service import ProjectService  # noqa

--- a/ropa/services/project_service.py
+++ b/ropa/services/project_service.py
@@ -1,0 +1,54 @@
+import json
+
+from ropa.gui.controller import DialogController
+
+
+class ProjectService:
+    def __init__(self, app):
+        self.app = app
+        self.dialog_controller = DialogController()
+
+    def _get_backend(self):
+        return self.app.backend
+
+    def new_file(self, filepath=None):
+        if filepath is None:
+            filepath = self.dialog_controller.file_dialog()
+
+        arch = self.dialog_controller.arch_dialog()
+
+        self._get_backend().set_arch(arch)
+        self._get_backend().set_filename(str(filepath))
+        self._get_backend().activate()
+
+        print(repr(filepath), arch)
+        return filepath, arch
+
+    def open_file(self, filepath=None):
+        if filepath is None:
+            filepath = self.dialog_controller.file_dialog()
+
+        save_data = None
+        with open(filepath, 'r') as infile:
+            save_data = json.load(infile)
+
+        self._get_backend().set_filename(save_data['filename'])
+        self._get_backend().set_arch(save_data['arch'])
+        self._get_backend().activate()
+
+        # doesn't work for now, need to settle on refactoring other stuff first
+        # self.chain = save_data['chain']
+        # self.favorites = save_data['favorites']
+
+    def save_file(self):
+        filepath = self.dialog_controller.file_dialog()
+        with open(filepath, 'w') as outfile:
+            save_data = {
+                # doesn't work now, settle on refactoring first
+                # 'chain': self.chain,
+                # 'favorites': self.favorites,
+                'filename': self._get_backend().get_filename(),
+                'arch': self._get_backend().get_arch()
+            }
+            json.dump(save_data, outfile)
+            outfile.close()


### PR DESCRIPTION
Fix #59

- Dialog GUI spawning code stays in DialogController
- Project-related (new, open, save) code taken from Backend and goes into ProjectService
- Update MenuItemController to reflect changes